### PR TITLE
gfs: enable checkpatch line length warnings by default

### DIFF
--- a/src/gfs/command.py
+++ b/src/gfs/command.py
@@ -82,7 +82,8 @@ def cmd_check(args):
         sys.exit(1)
 
     print(f"\n  ── checkpatch.pl on {patch_dir} ──\n")
-    cmd = ["./scripts/checkpatch.pl", "--strict", "--codespell"] + patches
+    cmd = ["./scripts/checkpatch.pl", "--max-line-length=80",
+           "--strict", "--codespell"] + patches
     print(f"  ▸ {' '.join(cmd)}\n")
     subprocess.run(cmd)
 


### PR DESCRIPTION
NOTE:
gfs check already runs checkpatch.pl with --strict by default.
This PR proposes also enabling --max-line-length=80 by default, as it
matches common Linux kernel style expectations.

This only affects checkpatch output (warnings/errors) and does not change
patch generation or selection. If preferred, this could be made optional
instead.